### PR TITLE
Added method to get transactions start timestamp

### DIFF
--- a/modules/api/src/main/java/io/fluo/api/client/SnapshotBase.java
+++ b/modules/api/src/main/java/io/fluo/api/client/SnapshotBase.java
@@ -50,4 +50,9 @@ public interface SnapshotBase {
    * Retrieves a {@link RowIterator} with the given {@link ScannerConfiguration}
    */
   RowIterator get(ScannerConfiguration config);
+
+  /**
+   * @return transactions start timestamp allocated from Oracle.
+   */
+  long getStartTimestamp();
 }

--- a/modules/api/src/main/java/io/fluo/api/types/TypedSnapshotBase.java
+++ b/modules/api/src/main/java/io/fluo/api/types/TypedSnapshotBase.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2014 Fluo authors (see AUTHORS)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -479,5 +479,10 @@ public class TypedSnapshotBase implements SnapshotBase {
     });
 
     return Collections.unmodifiableMap(DefaultedMap.decorate(ret, new Value((Bytes) null)));
+  }
+
+  @Override
+  public long getStartTimestamp() {
+    return snapshot.getStartTimestamp();
   }
 }

--- a/modules/core/src/main/java/io/fluo/core/impl/TransactionImpl.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/TransactionImpl.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2014 Fluo authors (see AUTHORS)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -488,18 +488,18 @@ public class TransactionImpl implements Transaction, Snapshot {
 
   /**
    * This function helps handle the following case
-   * 
+   *
    * <OL>
    * <LI>TX1 locls r1 col1
    * <LI>TX1 fails before unlocking
    * <LI>TX2 attempts to write r1:col1 w/o reading it
    * </OL>
-   * 
+   *
    * <p>
    * In this case TX2 would not roll back TX1, because it never read the column. This function
    * attempts to handle this case if TX2 fails. Only doing this in case of failures is cheaper than
    * trying to always read unread columns.
-   * 
+   *
    * @param cd Commit data
    */
   private void readUnread(CommitData cd) throws Exception {
@@ -770,7 +770,7 @@ public class TransactionImpl implements Transaction, Snapshot {
 
   /**
    * Sets the transactor of this transaction
-   * 
+   *
    * @param tnode TransactorNode
    * @return this Transaction
    */
@@ -811,5 +811,10 @@ public class TransactionImpl implements Transaction, Snapshot {
     // CHECKSTYLE:ON
     // TODO Log an error if transaction is not closed (See FLUO-486)
     close();
+  }
+
+  @Override
+  public long getStartTimestamp() {
+    return startTs;
   }
 }

--- a/modules/core/src/main/java/io/fluo/core/log/TracingTransaction.java
+++ b/modules/core/src/main/java/io/fluo/core/log/TracingTransaction.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2014 Fluo authors (see AUTHORS)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -165,5 +165,10 @@ public class TracingTransaction implements Transaction, Snapshot {
 
   public static boolean isTracingEnabled() {
     return log.isTraceEnabled() || summaryLog.isTraceEnabled() || collisionLog.isTraceEnabled();
+  }
+
+  @Override
+  public long getStartTimestamp() {
+    return tx.getStartTimestamp();
   }
 }

--- a/modules/core/src/test/java/io/fluo/core/types/MockSnapshotBase.java
+++ b/modules/core/src/test/java/io/fluo/core/types/MockSnapshotBase.java
@@ -165,4 +165,9 @@ public class MockSnapshotBase implements SnapshotBase {
     }
     return ret;
   }
+
+  @Override
+  public long getStartTimestamp() {
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
I was able to create a more efficient export recipe using the transactions start timestamp.