### PR TITLE
Stopped checkstyle mvn plugin from running at validate.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,7 +560,6 @@
             <goals>
               <goal>check</goal>
             </goals>
-            <phase>validate</phase>
             <configuration>
               <configLocation>contrib/fluo-checks.xml</configLocation>
               <encoding>UTF-8</encoding>


### PR DESCRIPTION
Code formatting was running after checkstyle for me.  I think this because both
plugins were running at the same maven phase.  Want formatting to run before
checkstyle so that it can fix any problems checkstyle would complain about.