### PR TITLE
Closes #580 - Modify dropwizard metrics timers and histograms to use …

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,8 +10,10 @@ different tools, below are some tools that have been used with Fluo.
    InfluxDB and viewing them in Grafana. The [fluo-dev] tool can also set up
    these tools for you and configure Fluo to send to them.
 
-2. JMX -  Fluo will setup a JMX reporter if no reporters are configured. The
-   JMX reporter makes it easy to see fluo stats in jconsole or jvisualvm.  
+2. JMX - Fluo can be configured to reports metrics via JMX which can be viewed
+   in jconsole or jvisualvm.  
+   
+3. CSV - Fluo can be configured to output metrics as CSV to a specified directory.
 
 Configuring Reporters
 ---------------------

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -83,6 +83,14 @@
       <artifactId>zookeeper</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mpierce.metrics.reservoir</groupId>
+      <artifactId>hdrhistogram-metrics-reservoir</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/modules/core/src/main/java/io/fluo/core/impl/FluoConfigurationImpl.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/FluoConfigurationImpl.java
@@ -27,6 +27,7 @@ public class FluoConfigurationImpl {
 
   public static final String ORACLE_PORT_PROP = FLUO_IMPL_PREFIX + ".oracle.port";
   public static final String WORKER_FINDER_PROP = FLUO_IMPL_PREFIX + ".worker.finder";
+  public static final String METRICS_RESERVOIR_PROP = FLUO_IMPL_PREFIX + ".metrics.reservoir";
   public static final String MIN_SLEEP_TIME_PROP = FLUO_IMPL_PREFIX
       + ScanTask.class.getSimpleName() + ".minSleep";
   public static final int MIN_SLEEP_TIME_DEFAULT = 5000;

--- a/modules/core/src/main/java/io/fluo/core/impl/LoadTask.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/LoadTask.java
@@ -68,8 +68,7 @@ public class LoadTask implements Runnable {
       } finally {
         if (txi != null) {
           try {
-            txi.getStats().report(env.getMetricNames(), status, loader.getClass(),
-                env.getSharedResources().getMetricRegistry());
+            txi.getStats().report(status, loader.getClass());
           } finally {
             tx.close();
           }

--- a/modules/core/src/main/java/io/fluo/core/impl/TransactionImpl.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/TransactionImpl.java
@@ -84,7 +84,7 @@ public class TransactionImpl implements Transaction, Snapshot {
   private final Set<Column> observedColumns;
   private final Environment env;
   final Map<Bytes, Set<Column>> columnsRead = new HashMap<>();
-  private final TxStats stats = new TxStats();
+  private final TxStats stats;
   private Notification notification;
   private Notification weakNotification;
   private TransactorNode tnode = null;
@@ -95,6 +95,7 @@ public class TransactionImpl implements Transaction, Snapshot {
     Preconditions.checkNotNull(env, "environment cannot be null");
     Preconditions.checkArgument(startTs >= 0, "startTs cannot be negative");
     this.env = env;
+    this.stats = new TxStats(env);
     this.startTs = startTs;
     this.observedColumns = env.getObservers().keySet();
 

--- a/modules/core/src/main/java/io/fluo/core/metrics/MetricsUtil.java
+++ b/modules/core/src/main/java/io/fluo/core/metrics/MetricsUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 Fluo authors (see AUTHORS)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.fluo.core.metrics;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Timer;
+import io.fluo.api.config.FluoConfiguration;
+import io.fluo.core.impl.FluoConfigurationImpl;
+import org.mpierce.metrics.reservoir.hdrhistogram.HdrHistogramResetOnSnapshotReservoir;
+
+public class MetricsUtil {
+
+  public static Reservoir getConfiguredReservoir(FluoConfiguration config) {
+    String clazz =
+        config.getString(FluoConfigurationImpl.METRICS_RESERVOIR_PROP,
+            HdrHistogramResetOnSnapshotReservoir.class.getName());
+    try {
+      return Class.forName(clazz).asSubclass(Reservoir.class).newInstance();
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static synchronized Timer addTimer(FluoConfiguration config, MetricRegistry registry,
+      String name) {
+    Timer timer = registry.getTimers().get(name);
+    if (timer == null) {
+      timer = new Timer(getConfiguredReservoir(config));
+      registry.register(name, timer);
+    }
+    return timer;
+  }
+
+  public static Timer getTimer(FluoConfiguration config, MetricRegistry registry, String name) {
+    Timer timer = registry.getTimers().get(name);
+    if (timer == null) {
+      return addTimer(config, registry, name);
+    }
+    return timer;
+  }
+
+  public static synchronized Histogram addHistogram(FluoConfiguration config,
+      MetricRegistry registry, String name) {
+    Histogram histogram = registry.getHistograms().get(name);
+    if (histogram == null) {
+      histogram = new Histogram(getConfiguredReservoir(config));
+      registry.register(name, histogram);
+    }
+    return histogram;
+  }
+
+  public static Histogram getHistogram(FluoConfiguration config, MetricRegistry registry,
+      String name) {
+    Histogram histogram = registry.getHistograms().get(name);
+    if (histogram == null) {
+      return addHistogram(config, registry, name);
+    }
+    return histogram;
+  }
+}

--- a/modules/core/src/main/java/io/fluo/core/metrics/starters/ConsoleReporterStarter.java
+++ b/modules/core/src/main/java/io/fluo/core/metrics/starters/ConsoleReporterStarter.java
@@ -23,8 +23,12 @@ import com.codahale.metrics.ConsoleReporter;
 import io.fluo.api.config.FluoConfiguration;
 import io.fluo.core.metrics.ReporterStarter;
 import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConsoleReporterStarter implements ReporterStarter {
+
+  private static final Logger log = LoggerFactory.getLogger(ConsoleReporterStarter.class);
 
   @Override
   public List<AutoCloseable> start(Params params) {
@@ -47,6 +51,9 @@ public class ConsoleReporterStarter implements ReporterStarter {
         ConsoleReporter.forRegistry(params.getMetricRegistry()).convertDurationsTo(durationUnit)
             .convertRatesTo(rateUnit).outputTo(out).build();
     reporter.start(config.getInt("frequency", 60), TimeUnit.SECONDS);
+
+    log.info("Reporting metrics to console");
+
     return Collections.singletonList((AutoCloseable) reporter);
   }
 

--- a/modules/core/src/main/java/io/fluo/core/metrics/starters/CsvReporterStarter.java
+++ b/modules/core/src/main/java/io/fluo/core/metrics/starters/CsvReporterStarter.java
@@ -23,16 +23,20 @@ import com.codahale.metrics.CsvReporter;
 import io.fluo.api.config.FluoConfiguration;
 import io.fluo.core.metrics.ReporterStarter;
 import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CsvReporterStarter implements ReporterStarter {
+
+  private static final Logger log = LoggerFactory.getLogger(CsvReporterStarter.class);
 
   @Override
   public List<AutoCloseable> start(Params params) {
     Configuration config =
         new FluoConfiguration(params.getConfiguration()).getReporterConfiguration("csv");
 
-    String file = config.getString("file", "");
-    if (!config.getBoolean("enable", false) || file.isEmpty()) {
+    String dir = config.getString("dir", "");
+    if (!config.getBoolean("enable", false) || dir.isEmpty()) {
       return Collections.emptyList();
     }
 
@@ -42,8 +46,11 @@ public class CsvReporterStarter implements ReporterStarter {
 
     CsvReporter reporter =
         CsvReporter.forRegistry(params.getMetricRegistry()).convertDurationsTo(durationUnit)
-            .convertRatesTo(rateUnit).build(new File(file));
+            .convertRatesTo(rateUnit).build(new File(dir));
     reporter.start(config.getInt("frequency", 60), TimeUnit.SECONDS);
+
+    log.info("Reporting metrics as csv to directory {}", dir);
+
     return Collections.singletonList((AutoCloseable) reporter);
   }
 

--- a/modules/core/src/main/java/io/fluo/core/metrics/starters/GraphiteReporterStarter.java
+++ b/modules/core/src/main/java/io/fluo/core/metrics/starters/GraphiteReporterStarter.java
@@ -23,8 +23,12 @@ import com.codahale.metrics.graphite.GraphiteReporter;
 import io.fluo.api.config.FluoConfiguration;
 import io.fluo.core.metrics.ReporterStarter;
 import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GraphiteReporterStarter implements ReporterStarter {
+
+  private static final Logger log = LoggerFactory.getLogger(GraphiteReporterStarter.class);
 
   @Override
   public List<AutoCloseable> start(Params params) {
@@ -47,6 +51,8 @@ public class GraphiteReporterStarter implements ReporterStarter {
         GraphiteReporter.forRegistry(params.getMetricRegistry()).convertDurationsTo(durationUnit)
             .convertRatesTo(rateUnit).prefixedWith(prefix).build(graphite);
     reporter.start(config.getInt("frequency", 60), TimeUnit.SECONDS);
+
+    log.info("Reporting metrics to graphite server {}:{}", host, port);
 
     return Collections.singletonList((AutoCloseable) reporter);
   }

--- a/modules/core/src/main/java/io/fluo/core/metrics/starters/JmxReporterStarter.java
+++ b/modules/core/src/main/java/io/fluo/core/metrics/starters/JmxReporterStarter.java
@@ -22,8 +22,12 @@ import com.codahale.metrics.JmxReporter;
 import io.fluo.api.config.FluoConfiguration;
 import io.fluo.core.metrics.ReporterStarter;
 import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JmxReporterStarter implements ReporterStarter {
+
+  private static final Logger log = LoggerFactory.getLogger(JmxReporterStarter.class);
 
   @Override
   public List<AutoCloseable> start(Params params) {
@@ -42,6 +46,9 @@ public class JmxReporterStarter implements ReporterStarter {
         JmxReporter.forRegistry(params.getMetricRegistry()).convertDurationsTo(durationUnit)
             .convertRatesTo(rateUnit).inDomain(params.getDomain()).build();
     reporter.start();
+
+    log.info("Reporting metrics to JMX");
+
     return Collections.singletonList((AutoCloseable) reporter);
   }
 }

--- a/modules/core/src/main/java/io/fluo/core/metrics/starters/Slf4jReporterStarter.java
+++ b/modules/core/src/main/java/io/fluo/core/metrics/starters/Slf4jReporterStarter.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 public class Slf4jReporterStarter implements ReporterStarter {
 
+  private static final Logger log = LoggerFactory.getLogger(Slf4jReporterStarter.class);
+
   @Override
   public List<AutoCloseable> start(Params params) {
     Configuration config =
@@ -45,6 +47,9 @@ public class Slf4jReporterStarter implements ReporterStarter {
         Slf4jReporter.forRegistry(params.getMetricRegistry()).convertDurationsTo(durationUnit)
             .convertRatesTo(rateUnit).outputTo(logger).build();
     reporter.start(config.getInt("frequency", 60), TimeUnit.SECONDS);
+
+    log.info("Reporting metrics using slf4j");
+
     return Collections.singletonList((AutoCloseable) reporter);
   }
 

--- a/modules/core/src/main/java/io/fluo/core/oracle/OracleClient.java
+++ b/modules/core/src/main/java/io/fluo/core/oracle/OracleClient.java
@@ -29,6 +29,7 @@ import io.fluo.accumulo.util.ZookeeperPath;
 import io.fluo.api.exceptions.FluoException;
 import io.fluo.core.impl.CuratorCnxnListener;
 import io.fluo.core.impl.Environment;
+import io.fluo.core.metrics.MetricsUtil;
 import io.fluo.core.thrift.OracleService;
 import io.fluo.core.thrift.Stamps;
 import io.fluo.core.util.CuratorUtil;
@@ -331,11 +332,11 @@ public class OracleClient implements AutoCloseable {
   public OracleClient(Environment env) {
     this.env = env;
     responseTimer =
-        env.getSharedResources().getMetricRegistry()
-            .timer(env.getMetricNames().getOracleResponseTime());
+        MetricsUtil.getTimer(env.getConfiguration(), env.getSharedResources().getMetricRegistry(),
+            env.getMetricNames().getOracleResponseTime());
     stampsHistogram =
-        env.getSharedResources().getMetricRegistry()
-            .histogram(env.getMetricNames().getOracleClientStamps());
+        MetricsUtil.getHistogram(env.getConfiguration(), env.getSharedResources()
+            .getMetricRegistry(), env.getMetricNames().getOracleClientStamps());
     timestampRetriever = new TimestampRetriever();
     thread = new Thread(timestampRetriever);
     thread.setDaemon(true);

--- a/modules/core/src/main/java/io/fluo/core/oracle/OracleServer.java
+++ b/modules/core/src/main/java/io/fluo/core/oracle/OracleServer.java
@@ -28,6 +28,7 @@ import io.fluo.accumulo.util.ZookeeperPath;
 import io.fluo.core.impl.CuratorCnxnListener;
 import io.fluo.core.impl.Environment;
 import io.fluo.core.impl.FluoConfigurationImpl;
+import io.fluo.core.metrics.MetricsUtil;
 import io.fluo.core.thrift.OracleService;
 import io.fluo.core.thrift.Stamps;
 import io.fluo.core.util.CuratorUtil;
@@ -177,9 +178,8 @@ public class OracleServer extends LeaderSelectorListenerAdapter implements Oracl
   public OracleServer(Environment env) throws Exception {
     this.env = env;
     stampsHistogram =
-        env.getSharedResources().getMetricRegistry()
-            .histogram(env.getMetricNames().getOracleServerStamps());
-
+        MetricsUtil.getHistogram(env.getConfiguration(), env.getSharedResources()
+            .getMetricRegistry(), env.getMetricNames().getOracleServerStamps());
     this.cnxnListener = new CuratorCnxnListener();
     this.maxTsPath = ZookeeperPath.ORACLE_MAX_TIMESTAMP;
     this.oraclePath = ZookeeperPath.ORACLE_SERVER;

--- a/modules/core/src/main/java/io/fluo/core/worker/WorkTask.java
+++ b/modules/core/src/main/java/io/fluo/core/worker/WorkTask.java
@@ -92,8 +92,7 @@ public class WorkTask implements Runnable {
         } finally {
           if (txi != null) {
             try {
-              txi.getStats().report(env.getMetricNames(), status.toString(), observer.getClass(),
-                  env.getSharedResources().getMetricRegistry());
+              txi.getStats().report(status.toString(), observer.getClass());
             } finally {
               tx.close();
             }

--- a/modules/distribution/src/main/config/fluo.properties
+++ b/modules/distribution/src/main/config/fluo.properties
@@ -111,7 +111,7 @@ io.fluo.admin.accumulo.classpath=${io.fluo.admin.hdfs.root}/fluo/lib/fluo-api-1.
 #io.fluo.metrics.reporter.console.frequency=60
 
 #io.fluo.metrics.reporter.csv.enable=false
-#io.fluo.metrics.reporter.csv.file=/tmp/fluo-metrics.csv
+#io.fluo.metrics.reporter.csv.dir=/tmp/
 #io.fluo.metrics.reporter.csv.rateUnit=seconds
 #io.fluo.metrics.reporter.csv.durationUnit=milliseconds
 #io.fluo.metrics.reporter.csv.frequency=60

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,16 @@
         <version>3.1</version>
       </dependency>
       <dependency>
+        <groupId>org.hdrhistogram</groupId>
+        <artifactId>HdrHistogram</artifactId>
+        <version>2.1.8</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mpierce.metrics.reservoir</groupId>
+        <artifactId>hdrhistogram-metrics-reservoir</artifactId>
+        <version>1.1.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${slf4j.version}</version>


### PR DESCRIPTION
…HdrHistogram backed reservoir

 * Fixed config to use directory instead of file for csv reporter
 * Fluo now prevents multiple reporters if HdrHistogramResetOnSnapshotReservoir is used
 * Made reservoir class configurable