### PR TITLE
Added 2nd conditional writer and logging of commit times

### DIFF
--- a/modules/core/src/main/java/io/fluo/core/impl/SharedResources.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/SharedResources.java
@@ -35,6 +35,7 @@ public class SharedResources implements AutoCloseable {
   private final Environment env;
   private final BatchWriter bw;
   private final ConditionalWriter cw;
+  private final ConditionalWriter bulkCw;
   private final SharedBatchWriter sbw;
   private final CuratorFramework curator;
   private OracleClient oracleClient = null;
@@ -60,6 +61,11 @@ public class SharedResources implements AutoCloseable {
             env.getTable(),
             new ConditionalWriterConfig().setAuthorizations(env.getAuthorizations())
                 .setMaxWriteThreads(numCWThreads));
+    bulkCw =
+        env.getConnector().createConditionalWriter(
+            env.getTable(),
+            new ConditionalWriterConfig().setAuthorizations(env.getAuthorizations())
+                .setMaxWriteThreads(numCWThreads));
     txInfoCache = new TxInfoCache(env);
     visCache = new VisibilityCache();
     metricRegistry = new MetricRegistry();
@@ -73,6 +79,11 @@ public class SharedResources implements AutoCloseable {
   public ConditionalWriter getConditionalWriter() {
     checkIfClosed();
     return cw;
+  }
+
+  public ConditionalWriter getBulkConditionalWriter() {
+    checkIfClosed();
+    return bulkCw;
   }
 
   public TxInfoCache getTxInfoCache() {
@@ -154,6 +165,7 @@ public class SharedResources implements AutoCloseable {
       oracleClient.close();
     }
     cw.close();
+    bulkCw.close();
     sbw.close();
     try {
       bw.close();

--- a/modules/core/src/main/java/io/fluo/core/impl/TxStats.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/TxStats.java
@@ -20,9 +20,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
-import io.fluo.api.config.FluoConfiguration;
 import io.fluo.api.data.Bytes;
 import io.fluo.api.data.Column;
 import io.fluo.core.metrics.MetricNames;
@@ -42,6 +40,9 @@ public class TxStats {
   private Map<Bytes, Set<Column>> rejected = Collections.emptyMap();
   private long commitTs = -1;
   private final Environment env;
+  private long precommitTime = -1;
+  private long commitPrimaryTime = -1;
+  private long finishCommitTime = -1;
 
   TxStats(Environment env) {
     this.startTime = System.currentTimeMillis();
@@ -62,6 +63,18 @@ public class TxStats {
 
   public long getTime() {
     return finishTime - startTime;
+  }
+
+  public long getPrecommitTime() {
+    return precommitTime;
+  }
+
+  public long getCommitPrimaryTime() {
+    return commitPrimaryTime;
+  }
+
+  public long getFinishCommitTime() {
+    return finishCommitTime;
   }
 
   public long getCollisions() {
@@ -160,5 +173,11 @@ public class TxStats {
       registry.meter(names.getTxLocksDead() + sn).mark(getDeadLocks());
     }
     registry.meter(names.getTxStatus() + status.toLowerCase() + "." + sn).mark();
+  }
+
+  public void setCommitTimes(long precommitTime, long commitPrimaryTime, long finishCommitTime) {
+    this.precommitTime = precommitTime;
+    this.commitPrimaryTime = commitPrimaryTime;
+    this.finishCommitTime = finishCommitTime;
   }
 }

--- a/modules/core/src/main/java/io/fluo/core/log/TracingTransaction.java
+++ b/modules/core/src/main/java/io/fluo/core/log/TracingTransaction.java
@@ -222,9 +222,11 @@ public class TracingTransaction implements Transaction, Snapshot {
         className = clazz.getSimpleName();
       }
       // TODO log total # read, see fluo-426
-      summaryLog.trace("txid: {} thread : {} time: {} #ret: {} #set: {} #collisions: {} "
-          + "waitTime: {} committed: {} class: {}", txid, Thread.currentThread().getId(),
-          stats.getTime(), stats.getEntriesReturned(), stats.getEntriesSet(),
+      summaryLog.trace(
+          "txid: {} thread : {} time: {} ({} {} {}) #ret: {} #set: {} #collisions: {} "
+              + "waitTime: {} committed: {} class: {}", txid, Thread.currentThread().getId(),
+          stats.getTime(), stats.getPrecommitTime(), stats.getCommitPrimaryTime(),
+          stats.getFinishCommitTime(), stats.getEntriesReturned(), stats.getEntriesSet(),
           stats.getCollisions(), stats.getLockWaitTime(), committed, className);
     }
     tx.close();

--- a/modules/integration/src/test/java/io/fluo/integration/log/LogIT.java
+++ b/modules/integration/src/test/java/io/fluo/integration/log/LogIT.java
@@ -197,23 +197,24 @@ public class LogIT extends ITBaseMini {
       logger.setLevel(level);
     }
 
+
     String logMsgs = writer.toString().replace('\n', ' ');
 
     Assert
         .assertTrue(logMsgs
-            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ #ret: 0 #set: 1 #collisions: 0 waitTime: \\d+ committed: true class: TriggerLoader.*"));
+            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ \\(\\d+ \\d+ \\d+\\) #ret: 0 #set: 1 #collisions: 0 waitTime: \\d+ committed: true class: TriggerLoader.*"));
     Assert
         .assertTrue(logMsgs
-            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ #ret: 1 #set: 1 #collisions: 0 waitTime: \\d+ committed: true class: SimpleLoader.*"));
+            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ \\(\\d+ \\d+ \\d+\\) #ret: 1 #set: 1 #collisions: 0 waitTime: \\d+ committed: true class: SimpleLoader.*"));
     Assert
         .assertTrue(logMsgs
-            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ #ret: 1 #set: 1 #collisions: 1 waitTime: \\d+ committed: false class: SimpleLoader.*"));
+            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ \\(-1 -1 -1\\) #ret: 1 #set: 1 #collisions: 1 waitTime: \\d+ committed: false class: SimpleLoader.*"));
     Assert
         .assertTrue(logMsgs
-            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ #ret: 2 #set: 1 #collisions: 0 waitTime: \\d+ committed: true class: TestObserver.*"));
+            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ \\(\\d+ \\d+ \\d+\\) #ret: 2 #set: 1 #collisions: 0 waitTime: \\d+ committed: true class: TestObserver.*"));
     Assert
         .assertTrue(logMsgs
-            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ #ret: 2 #set: 1 #collisions: 1 waitTime: \\d+ committed: false class: TestObserver.*"));
+            .matches(".*txid: \\d+ thread : \\d+ time: \\d+ \\(-1 -1 -1\\) #ret: 2 #set: 1 #collisions: 1 waitTime: \\d+ committed: false class: TestObserver.*"));
   }
 
   @Test


### PR DESCRIPTION
Added some logging of commit times and noticed that the two
single conditional mutation for the primary were getting
held up by bigger batches of mutations.  So created a 2nd
conditional writer for really small numbers of updates to
decrease overall transaction time.