### PR TITLE
fixes #591 no longer wait on batch writer when finishing commit

### DIFF
--- a/modules/core/src/main/java/io/fluo/core/client/FluoClientImpl.java
+++ b/modules/core/src/main/java/io/fluo/core/client/FluoClientImpl.java
@@ -84,7 +84,14 @@ public class FluoClientImpl implements FluoClient {
 
   @Override
   public Transaction newTransaction() {
-    TransactionImpl tx = new TransactionImpl(env);
+    TransactionImpl tx = new TransactionImpl(env) {
+      @Override
+      public void commit() {
+        super.commit();
+        // wait for any async mutations that transaction write to flush
+        env.getSharedResources().getBatchWriter().waitForAsyncFlush();
+      }
+    };
     if (TracingTransaction.isTracingEnabled()) {
       return new TracingTransaction(tx);
     }

--- a/modules/core/src/main/java/io/fluo/core/client/LoaderExecutorImpl.java
+++ b/modules/core/src/main/java/io/fluo/core/client/LoaderExecutorImpl.java
@@ -123,6 +123,9 @@ public class LoaderExecutorImpl implements LoaderExecutor {
     if (exceptionRef.get() != null) {
       throw new RuntimeException(exceptionRef.get());
     }
+
+    // wait for any async mutations that transactions write to flush
+    env.getSharedResources().getBatchWriter().waitForAsyncFlush();
   }
 
 }


### PR DESCRIPTION
Instead push two list of mutations to shared batch writer to write in
background.  The first list of mutations if flushed before writing the second.