### PR TITLE
fixes #597 moved Fluo Formatter functionality to Fluo scan command

### DIFF
--- a/modules/accumulo/src/main/java/io/fluo/accumulo/format/FluoFormatter.java
+++ b/modules/accumulo/src/main/java/io/fluo/accumulo/format/FluoFormatter.java
@@ -14,9 +14,9 @@
 
 package io.fluo.accumulo.format;
 
-import java.util.Iterator;
 import java.util.Map.Entry;
 
+import com.google.common.base.Function;
 import io.fluo.accumulo.util.ColumnConstants;
 import io.fluo.accumulo.util.NotificationUtil;
 import io.fluo.accumulo.values.DelLockValue;
@@ -27,25 +27,11 @@ import io.fluo.api.data.Column;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.util.format.Formatter;
 
 /**
  * Converts Accumulo table data to a human-readable Fluo format
  */
-public class FluoFormatter implements Formatter {
-
-  private Iterator<Entry<Key, Value>> scanner;
-
-  @Override
-  public boolean hasNext() {
-    return scanner.hasNext();
-  }
-
-  @Override
-  public String next() {
-    Entry<Key, Value> entry = scanner.next();
-    return toString(entry);
-  }
+public class FluoFormatter implements Function<Entry<Key, Value>, String> {
 
   private static void appendByte(StringBuilder sb, byte b) {
     if (b >= 32 && b <= 126 && b != '\\') {
@@ -154,12 +140,7 @@ public class FluoFormatter implements Formatter {
   }
 
   @Override
-  public void remove() {
-    scanner.remove();
-  }
-
-  @Override
-  public void initialize(Iterable<Entry<Key, Value>> scanner, boolean printTimestamps) {
-    this.scanner = scanner.iterator();
+  public String apply(Entry<Key, Value> input) {
+    return toString(input);
   }
 }

--- a/modules/cluster/src/main/java/io/fluo/cluster/runner/ScanOptions.java
+++ b/modules/cluster/src/main/java/io/fluo/cluster/runner/ScanOptions.java
@@ -44,6 +44,13 @@ public class ScanOptions {
       description = "Hex encode non ascii bytes", arity = 1)
   public boolean hexEncNonAscii = true;
 
+  @Parameter(
+      names = "--raw",
+      help = true,
+      description = "Show underlying key/values stored in Accumulo. Interprets the data using Fluo "
+          + "internal schema, making it easier to comprehend.")
+  public boolean scanAccumuloTable = false;
+
   public String getStartRow() {
     return startRow;
   }

--- a/modules/core/src/main/java/io/fluo/core/client/FluoAdminImpl.java
+++ b/modules/core/src/main/java/io/fluo/core/client/FluoAdminImpl.java
@@ -23,8 +23,19 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.commons.configuration.ConfigurationUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.hadoop.io.Text;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.NodeExistsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Preconditions;
-import io.fluo.accumulo.format.FluoFormatter;
+
 import io.fluo.accumulo.iterators.GarbageCollectionIterator;
 import io.fluo.accumulo.iterators.NotificationIterator;
 import io.fluo.accumulo.util.AccumuloProps;
@@ -43,16 +54,6 @@ import io.fluo.core.util.AccumuloUtil;
 import io.fluo.core.util.ByteUtil;
 import io.fluo.core.util.CuratorUtil;
 import io.fluo.core.worker.ObserverContext;
-import org.apache.accumulo.core.client.Connector;
-import org.apache.accumulo.core.client.IteratorSetting;
-import org.apache.accumulo.core.iterators.IteratorUtil;
-import org.apache.commons.configuration.ConfigurationUtils;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.hadoop.io.Text;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.KeeperException.NodeExistsException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Fluo Admin Implementation
@@ -202,9 +203,6 @@ public class FluoAdminImpl implements FluoAdmin {
 
     conn.tableOperations().attachIterator(config.getAccumuloTable(), ntfyIter,
         EnumSet.of(IteratorUtil.IteratorScope.majc, IteratorUtil.IteratorScope.minc));
-
-    conn.tableOperations().setProperty(config.getAccumuloTable(),
-        AccumuloProps.TABLE_FORMATTER_CLASS, FluoFormatter.class.getName());
   }
 
   @Override

--- a/modules/integration/src/test/java/io/fluo/integration/ITBase.java
+++ b/modules/integration/src/test/java/io/fluo/integration/ITBase.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.fluo.accumulo.format.FluoFormatter;
 import io.fluo.api.client.FluoClient;
 import io.fluo.api.client.Snapshot;
 import io.fluo.api.config.FluoConfiguration;
@@ -32,9 +31,7 @@ import io.fluo.api.iterator.ColumnIterator;
 import io.fluo.api.iterator.RowIterator;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
-import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
-import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.MiniAccumuloConfig;
 import org.apache.accumulo.minicluster.MiniAccumuloInstance;
@@ -97,17 +94,6 @@ public class ITBase {
 
   public String getNextTableName() {
     return TABLE_BASE + tableCounter.incrementAndGet();
-  }
-
-  protected void printTable() throws Exception {
-    Scanner scanner = conn.createScanner(getCurTableName(), Authorizations.EMPTY);
-    FluoFormatter af = new FluoFormatter();
-
-    af.initialize(scanner, true);
-
-    while (af.hasNext()) {
-      System.out.println(af.next());
-    }
   }
 
   protected void printSnapshot() throws Exception {

--- a/modules/integration/src/test/java/io/fluo/integration/impl/StochasticBankIT.java
+++ b/modules/integration/src/test/java/io/fluo/integration/impl/StochasticBankIT.java
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.collect.Iterables;
 import io.fluo.accumulo.format.FluoFormatter;
 import io.fluo.api.config.ScannerConfiguration;
 import io.fluo.api.data.Bytes;
@@ -259,11 +260,9 @@ public class StochasticBankIT extends ITBaseImpl {
     Writer fw = new BufferedWriter(new FileWriter(tmpFile));
 
     Scanner scanner = env.getConnector().createScanner(env.getTable(), env.getAuthorizations());
-    FluoFormatter af = new FluoFormatter();
-    af.initialize(scanner, true);
 
-    while (af.hasNext()) {
-      fw.append(af.next());
+    for (String cell : Iterables.transform(scanner, new FluoFormatter())) {
+      fw.append(cell);
       fw.append("\n");
     }
 


### PR DESCRIPTION
Below is some output of running scan with the new `--raw` option.   Its nice having this in the scan command for debugging instead of having to switch to the accumulo shell.

```
$ ./bin/fluo scan stress  --raw -s 06:171c:08:000000002e490000 -e 06:171c:08:000000002e490000
Connecting to Fluo instance (localhost/fluo) using config (apps/stress/conf/fluo.properties)
Scanning data in Accumulo directly for 'stress' application.
06:171c:08:000000002e490000 count:seen [] 20380-WRITE	20151 
06:171c:08:000000002e490000 count:seen [] 1-WRITE	0 
06:171c:08:000000002e490000 count:seen [] 20151-DATA	78
06:171c:08:000000002e490000 count:seen [] 0-DATA	77
06:171c:08:000000002e490000 count:wait [] 20380-TX_DONE	
06:171c:08:000000002e490000 count:wait [] 20380-WRITE	20151 DELETE PRIMARY
06:171c:08:000000002e490000 count:wait [] 20020-WRITE	19947 
06:171c:08:000000002e490000 count:wait [] 19947-DATA	1
06:171c:08:000000002e490000 ntfy:count:wait [] 20151-DELETE	
06:171c:08:000000002e490000 ntfy:count:wait [] 20020-INSERT	
```

```
$ ./bin/fluo scan stress -s 06:171c:08:000000002e490000 -e 06:171c:08:000000002e490000
Connecting to Fluo instance (localhost/fluo) using config (apps/stress/conf/fluo.properties)
Scanning snapshot of data in Fluo 'stress' application.
06:171c:08:000000002e490000 count seen 	78
```
