### PR TITLE
Fixes #623 #170. Made Prewrite and scan iterators seek.  Added optimi…

### DIFF
--- a/modules/accumulo/src/main/java/io/fluo/accumulo/iterators/RollbackCheckIterator.java
+++ b/modules/accumulo/src/main/java/io/fluo/accumulo/iterators/RollbackCheckIterator.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Map;
 
 import io.fluo.accumulo.util.ColumnConstants;
-import io.fluo.accumulo.values.DelLockValue;
 import io.fluo.accumulo.values.WriteValue;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -108,13 +107,11 @@ public class RollbackCheckIterator implements SortedKeyValueIterator<Key, Value>
           return;
         }
       } else if (colType == ColumnConstants.DEL_LOCK_PREFIX) {
-        long timePtr = DelLockValue.getTimestamp(source.getTopValue().get());
-
-        if (timePtr > invalidationTime) {
-          invalidationTime = timePtr;
+        if (ts > invalidationTime) {
+          invalidationTime = ts;
         }
 
-        if (timePtr == lockTime) {
+        if (ts == lockTime) {
           hasTop = true;
           return;
         }

--- a/modules/accumulo/src/main/java/io/fluo/accumulo/iterators/TimestampSkippingIterator.java
+++ b/modules/accumulo/src/main/java/io/fluo/accumulo/iterators/TimestampSkippingIterator.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2016 Fluo authors (see AUTHORS)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.fluo.accumulo.iterators;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+
+import io.fluo.accumulo.util.ColumnConstants;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
+import org.apache.accumulo.core.iterators.WrappingIterator;
+import org.apache.accumulo.core.iterators.system.DeletingIterator;
+import org.apache.accumulo.core.iterators.system.SourceSwitchingIterator;
+import org.apache.accumulo.core.iterators.system.SynchronizedIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The purpose of this iterator it make seeking within a columns timestamp range efficient.
+ * Accumulo's builtin deleting iterator gets in the way when trying to efficiently do these seeks.
+ * Therefore this class attempts to remove that iterator via reflection.
+ */
+
+public class TimestampSkippingIterator implements SortedKeyValueIterator<Key, Value> {
+
+  private final SortedKeyValueIterator<Key, Value> source;
+  private Range range;
+  private Collection<ByteSequence> fams;
+  private boolean inclusive;
+  private boolean hasSeeked = false;
+
+  private static final Logger log = LoggerFactory.getLogger(TimestampSkippingIterator.class);
+
+  TimestampSkippingIterator(SortedKeyValueIterator<Key, Value> source) {
+    this.source = source;
+  }
+
+  @Override
+  public void init(SortedKeyValueIterator<Key, Value> source, Map<String, String> options,
+      IteratorEnvironment env) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean hasTop() {
+    return source.hasTop();
+  }
+
+  @Override
+  public void next() throws IOException {
+    source.next();
+  }
+
+  public void skipToTimestamp(Key curCol, long timestamp) throws IOException {
+    source.next();
+    int count = 0;
+    while (source.hasTop()
+        && curCol.equals(source.getTopKey(), PartialKey.ROW_COLFAM_COLQUAL_COLVIS)
+        && timestamp < source.getTopKey().getTimestamp()) {
+      if (count == 10) {
+        // seek to prefix
+        Key seekKey = new Key(curCol);
+        seekKey.setTimestamp(timestamp);
+        Range newRange = new Range(seekKey, true, range.getEndKey(), range.isEndKeyInclusive());
+        seek(newRange);
+        break;
+      }
+      source.next();
+      count++;
+    }
+  }
+
+  public void skipToPrefix(Key curCol, long prefix) throws IOException {
+    // first possible timestamp in sorted order for this prefix
+    long timestamp = prefix | ColumnConstants.TIMESTAMP_MASK;
+    skipToTimestamp(curCol, timestamp);
+  }
+
+  public void skipColumn(Key curCol) throws IOException {
+    source.next();
+    int count = 0;
+    while (source.hasTop()
+        && curCol.equals(source.getTopKey(), PartialKey.ROW_COLFAM_COLQUAL_COLVIS)) {
+      if (count == 10) {
+        Key seekKey = curCol.followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS);
+        Range newRange = new Range(seekKey, true, range.getEndKey(), range.isEndKeyInclusive());
+        seek(newRange);
+        break;
+      }
+      source.next();
+      count++;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static SortedKeyValueIterator<Key, Value> getParent(
+      SortedKeyValueIterator<Key, Value> iter) {
+    try {
+      if (iter instanceof WrappingIterator) {
+        Field field = WrappingIterator.class.getDeclaredField("source");
+        field.setAccessible(true);
+        return (SortedKeyValueIterator<Key, Value>) field.get(iter);
+      } else if (iter instanceof SourceSwitchingIterator) {
+        // TODO could sync on SSI
+        Field field = SourceSwitchingIterator.class.getDeclaredField("iter");
+        field.setAccessible(true);
+        return (SortedKeyValueIterator<Key, Value>) field.get(iter);
+      } else if (iter instanceof SynchronizedIterator) {
+        Field field = SynchronizedIterator.class.getDeclaredField("source");
+        field.setAccessible(true);
+        return (SortedKeyValueIterator<Key, Value>) field.get(iter);
+      } else if (iter instanceof SortedMapIterator) {
+        return null;
+      } else {
+        // System.out.println("unknown type " + iter.getClass().getName());
+        return null;
+      }
+    } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
+      log.debug(e.getMessage(), e);
+      return null;
+    }
+  }
+
+  private static void setParent(SortedKeyValueIterator<Key, Value> iter,
+      SortedKeyValueIterator<Key, Value> newParent) {
+    try {
+      if (iter instanceof WrappingIterator) {
+        Field field = WrappingIterator.class.getDeclaredField("source");
+        field.setAccessible(true);
+        field.set(iter, newParent);
+      }
+    } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
+      log.debug(e.getMessage(), e);
+    }
+  }
+
+  private static void removeDeletingIterator(SortedKeyValueIterator<Key, Value> source) {
+
+    SortedKeyValueIterator<Key, Value> prev = source;
+    SortedKeyValueIterator<Key, Value> parent = getParent(source);
+
+    while (parent != null && !(parent instanceof DeletingIterator)) {
+      prev = parent;
+      parent = getParent(parent);
+    }
+
+    if (parent != null && parent instanceof DeletingIterator) {
+      SortedKeyValueIterator<Key, Value> delParent = getParent(parent);
+      if (delParent != null) {
+        setParent(prev, delParent);
+      }
+    }
+  }
+
+  private void seek(Range range) throws IOException {
+    if (hasSeeked) {
+      // Making assumptions based on how Accumulo currently works. Currently Accumulo does not set
+      // up iterators until the 1st seek. Therefore can only remove the deleting iter after the 1st
+      // seek. Also, Accumulo may switch data sources and re-setup the deleting iterator, thats why
+      // this iterator keeps trying to remove it.
+      removeDeletingIterator(source);
+    }
+    source.seek(range, fams, inclusive);
+    hasSeeked = true;
+  }
+
+  @Override
+  public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive)
+      throws IOException {
+    this.range = range;
+    this.fams = columnFamilies;
+    this.inclusive = inclusive;
+    seek(range);
+  }
+
+  @Override
+  public Key getTopKey() {
+    return source.getTopKey();
+  }
+
+  @Override
+  public Value getTopValue() {
+    return source.getTopValue();
+  }
+
+  @Override
+  public SortedKeyValueIterator<Key, Value> deepCopy(IteratorEnvironment env) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/modules/accumulo/src/main/java/io/fluo/accumulo/iterators/TimestampSkippingIterator.java
+++ b/modules/accumulo/src/main/java/io/fluo/accumulo/iterators/TimestampSkippingIterator.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The purpose of this iterator it make seeking within a columns timestamp range efficient.
+ * The purpose of this iterator is to make seeking within a columns timestamp range efficient.
  * Accumulo's builtin deleting iterator gets in the way when trying to efficiently do these seeks.
  * Therefore this class attempts to remove that iterator via reflection.
  */

--- a/modules/accumulo/src/test/java/io/fluo/accumulo/iterators/GarbageCollectionIteratorTest.java
+++ b/modules/accumulo/src/test/java/io/fluo/accumulo/iterators/GarbageCollectionIteratorTest.java
@@ -324,7 +324,7 @@ public class GarbageCollectionIteratorTest {
     // test del_lock that is primary
     input = new TestData();
     input.add("0 f q WRITE 22", "19");
-    input.add("0 f q DEL_LOCK 13", "11 PRIMARY");
+    input.add("0 f q DEL_LOCK 11", "13 PRIMARY");
     input.add("0 f q LOCK 11", "0 f q");
     input.add("0 f q DATA 19", "19");
     input.add("0 f q DATA 11", "15");
@@ -333,7 +333,7 @@ public class GarbageCollectionIteratorTest {
 
     expected = new TestData();
     expected.add("0 f q WRITE 22", "19");
-    expected.add("0 f q DEL_LOCK 13", "11 PRIMARY");
+    expected.add("0 f q DEL_LOCK 11", "13 PRIMARY");
     expected.add("0 f q DATA 19", "19");
 
     Assert.assertEquals(expected, output);
@@ -351,7 +351,7 @@ public class GarbageCollectionIteratorTest {
 
     // ensure that timestamp in value is used
     input = new TestData();
-    input.add("0 f q DEL_LOCK 13", "3 PRIMARY");
+    input.add("0 f q DEL_LOCK 3", "13 PRIMARY");
     input.add("0 f q LOCK 11", "0 f q");
     input.add("0 f q DATA 11", "15");
 
@@ -363,7 +363,7 @@ public class GarbageCollectionIteratorTest {
     input = new TestData();
 
     input.add("0 f q WRITE 11", "10");
-    input.add("0 f q DEL_LOCK 13", "3");
+    input.add("0 f q DEL_LOCK 3", "13");
     input.add("0 f q LOCK 3", "0 f q");
     input.add("0 f q DATA 10", "17");
     input.add("0 f q DATA 3", "15");

--- a/modules/accumulo/src/test/java/io/fluo/accumulo/iterators/PrewriteIteratorTest.java
+++ b/modules/accumulo/src/test/java/io/fluo/accumulo/iterators/PrewriteIteratorTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2014 Fluo authors (see AUTHORS)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.fluo.accumulo.iterators;
+
+import java.io.IOException;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PrewriteIteratorTest {
+
+  PrewriteIterator newPI(TestData input, long snapTime) {
+    PrewriteIterator ni = new PrewriteIterator();
+
+    IteratorEnvironment env = TestIteratorEnv.create(IteratorScope.scan, false);
+
+    try {
+      IteratorSetting cfg = new IteratorSetting(10, PrewriteIterator.class);
+      PrewriteIterator.setSnaptime(cfg, snapTime);
+      ni.init(new SortedMapIterator(input.data), cfg.getOptions(), env);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return ni;
+  }
+
+  PrewriteIterator newPI(TestData input, long snapTime, long ntfyTime) {
+    PrewriteIterator ni = new PrewriteIterator();
+
+    IteratorEnvironment env = TestIteratorEnv.create(IteratorScope.scan, false);
+
+    try {
+      IteratorSetting cfg = new IteratorSetting(10, PrewriteIterator.class);
+      PrewriteIterator.setSnaptime(cfg, snapTime);
+      PrewriteIterator.enableAckCheck(cfg, ntfyTime);
+      ni.init(new SortedMapIterator(input.data), cfg.getOptions(), env);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return ni;
+  }
+
+  public void addLots(TestData input) {
+    for (int i = 3; i < 100; i += 3) {
+      input.add("0 f q TX_DONE " + (i + 1), "" + i);
+      input.add("0 f q WRITE " + (i + 1), "" + i);
+      input.add("0 f q LOCK " + i, "0 f q");
+      input.add("0 f q DATA " + i, "15");
+    }
+  }
+
+  @Test
+  public void testAck() {
+    TestData input = new TestData();
+
+    input.add("0 f q WRITE 116", "111");
+    input.add("0 f q LOCK 111", "0 f q");
+    input.add("0 f q DATA 111", "15");
+    input.add("0 f q ACK 111", "");
+
+    for (int i = 0; i < 2; i++) {
+      TestData output = new TestData(newPI(input, 117, 100), Range.exact("0", "f", "q"));
+      TestData expected = new TestData().add("0 f q ACK 111", "");
+      Assert.assertEquals(expected, output);
+
+      output = new TestData(newPI(input, 117, 116), Range.exact("0", "f", "q"));
+      Assert.assertEquals(0, output.data.size());
+
+      output = new TestData(newPI(input, 112, 100), Range.exact("0", "f", "q"));
+      expected = new TestData().add("0 f q WRITE 116", "111");
+      Assert.assertEquals(expected, output);
+
+      addLots(input);
+      input.add("0 f q TX_DONE 116", "111");
+      for (int j = 3; j < 100; j += 3) {
+        input.add("0 f q ACK " + j, "");
+      }
+    }
+  }
+
+  @Test
+  public void testLockedCell() throws Exception {
+    TestData input = new TestData();
+
+    // the row is locked
+    input.add("0 f q WRITE 116", "111");
+    input.add("0 f q LOCK 121", "0 f q");
+    input.add("0 f q LOCK 111", "0 f q");
+    input.add("0 f q DATA 111", "15");
+
+    TestData expected = new TestData().add("0 f q LOCK 121", "0 f q");
+
+    for (long ts : new long[] {117, 122}) {
+      TestData output = new TestData(newPI(input, ts), Range.exact("0", "f", "q"));
+      Assert.assertEquals(expected, output);
+    }
+
+    input.add("0 f q TX_DONE 116", "111");
+    for (long ts : new long[] {117, 122}) {
+      TestData output = new TestData(newPI(input, ts), Range.exact("0", "f", "q"));
+      Assert.assertEquals(expected, output);
+    }
+
+    addLots(input);
+    for (long ts : new long[] {117, 122}) {
+      TestData output = new TestData(newPI(input, ts), Range.exact("0", "f", "q"));
+      Assert.assertEquals(expected, output);
+    }
+  }
+
+  @Test
+  public void testWriteAfterStart() throws Exception {
+    TestData input = new TestData();
+
+    // the row is locked
+    input.add("0 f q WRITE 116", "111");
+    input.add("0 f q LOCK 121", "0 f q");
+    input.add("0 f q LOCK 111", "0 f q");
+    input.add("0 f q DATA 111", "15");
+
+    TestData expected = new TestData().add("0 f q WRITE 116", "111");
+
+    for (long ts : new long[] {108, 112}) {
+      TestData output = new TestData(newPI(input, ts), Range.exact("0", "f", "q"));
+      Assert.assertEquals(expected, output);
+    }
+
+    input.add("0 f q TX_DONE 116", "111");
+    for (long ts : new long[] {108, 112}) {
+      TestData output = new TestData(newPI(input, ts), Range.exact("0", "f", "q"));
+      Assert.assertEquals(expected, output);
+    }
+
+    addLots(input);
+    for (long ts : new long[] {108, 112}) {
+      TestData output = new TestData(newPI(input, ts), Range.exact("0", "f", "q"));
+      Assert.assertEquals(expected, output);
+    }
+  }
+
+  @Test
+  public void testDelLock() {
+    TestData input = new TestData();
+
+    // the row is locked
+    input.add("0 f q DEL_LOCK 111", "ABORT");
+    input.add("0 f q LOCK 111", "0 f q");
+    input.add("0 f q DATA 111", "15");
+
+    for (int i = 0; i < 2; i++) {
+
+      TestData output = new TestData(newPI(input, 117), Range.exact("0", "f", "q"));
+      Assert.assertEquals(new TestData(), output);
+
+      output = new TestData(newPI(input, 108), Range.exact("0", "f", "q"));
+      TestData expected = new TestData();
+      expected.add("0 f q DEL_LOCK 111", "ABORT");
+      Assert.assertEquals(expected, output);
+
+      input.add("0 f q TX_DONE 116", "111");
+      output = new TestData(newPI(input, 117), Range.exact("0", "f", "q"));
+      Assert.assertEquals(0, output.data.size());
+
+      output = new TestData(newPI(input, 108), Range.exact("0", "f", "q"));
+      Assert.assertEquals(expected, output);
+
+      addLots(input);
+    }
+  }
+
+  @Test
+  public void testWriteAndDelLockMax() {
+    // ensure the delete lock or write with max timestamp invalidates lock
+    TestData input = new TestData();
+
+    input.add("0 f q WRITE 116", "111");
+    input.add("0 f q LOCK 111", "0 f q");
+    input.add("0 f q DEL_LOCK 108", "ABORT");
+
+    TestData output = new TestData(newPI(input, 117), Range.exact("0", "f", "q"));
+    Assert.assertEquals(0, output.data.size());
+
+    output = new TestData(newPI(input, 111), Range.exact("0", "f", "q"));
+    TestData expected = new TestData();
+    expected.add("0 f q WRITE 116", "111");
+    Assert.assertEquals(expected, output);
+
+    input = new TestData();
+
+    input.add("0 f q DEL_LOCK 116", "ABORT");
+    input.add("0 f q LOCK 111", "0 f q");
+    input.add("0 f q WRITE 108", "100");
+
+    output = new TestData(newPI(input, 117), Range.exact("0", "f", "q"));
+    Assert.assertEquals(0, output.data.size());
+
+    output = new TestData(newPI(input, 111), Range.exact("0", "f", "q"));
+    expected = new TestData();
+    expected.add("0 f q DEL_LOCK 116", "ABORT");
+    Assert.assertEquals(expected, output);
+  }
+
+  @Test
+  public void testWriteInvalidatesLock() {
+    TestData input = new TestData();
+
+    // the row is locked
+    input.add("0 f q WRITE 116", "111");
+    input.add("0 f q LOCK 111", "0 f q");
+    input.add("0 f q DATA 111", "15");
+
+    TestData output = new TestData(newPI(input, 117), Range.exact("0", "f", "q"));
+    Assert.assertEquals(0, output.data.size());
+
+    input.add("0 f q TX_DONE 116", "111");
+    output = new TestData(newPI(input, 117), Range.exact("0", "f", "q"));
+    Assert.assertEquals(0, output.data.size());
+
+    addLots(input);
+    output = new TestData(newPI(input, 117), Range.exact("0", "f", "q"));
+    Assert.assertEquals(0, output.data.size());
+  }
+}

--- a/modules/accumulo/src/test/java/io/fluo/accumulo/iterators/TestData.java
+++ b/modules/accumulo/src/test/java/io/fluo/accumulo/iterators/TestData.java
@@ -108,8 +108,12 @@ public class TestData {
         break;
       case "DEL_LOCK":
         ts |= ColumnConstants.DEL_LOCK_PREFIX;
-        long lockTs = Long.parseLong(value.split("\\s+")[0]);
-        val = DelLockValue.encode(lockTs, value.contains("PRIMARY"), value.contains("ROLLBACK"));
+        if (value.contains("ROLLBACK") || value.contains("ABORT")) {
+          val = DelLockValue.encodeRollback(value.contains("PRIMARY"), true);
+        } else {
+          long commitTs = Long.parseLong(value.split("\\s+")[0]);
+          val = DelLockValue.encodeCommit(commitTs, value.contains("PRIMARY"));
+        }
         break;
       case "ntfy":
         break;

--- a/modules/core/src/main/java/io/fluo/core/impl/LockResolver.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/LockResolver.java
@@ -85,7 +85,7 @@ public class LockResolver {
 
   /**
    * Attempts to roll forward or roll back a set of locks encountered by a transaction reading data.
-   * 
+   *
    * @param env environment
    * @param startTs The logical start time from the oracle of the transaction that encountered the
    *        lock
@@ -189,8 +189,8 @@ public class LockResolver {
       Mutation mut = getMutation(entry.getKey().getRowData(), mutations);
       Key k = entry.getKey();
       mut.put(k.getColumnFamilyData().toArray(), k.getColumnQualifierData().toArray(),
-          k.getColumnVisibilityParsed(), ColumnConstants.DEL_LOCK_PREFIX | startTs,
-          DelLockValue.encode(lockTs, false, true));
+          k.getColumnVisibilityParsed(), ColumnConstants.DEL_LOCK_PREFIX | lockTs,
+          DelLockValue.encodeRollback(false, true));
     }
 
   }
@@ -205,10 +205,8 @@ public class LockResolver {
         new ConditionalFlutation(env, prc.prow, new FluoCondition(env, prc.pcol).setIterators(
             iterConf).setValue(lockValue));
 
-    // TODO sanity check on lockTs vs startTs
-
-    delLockMutation.put(prc.pcol, ColumnConstants.DEL_LOCK_PREFIX | startTs,
-        DelLockValue.encode(prc.startTs, true, true));
+    delLockMutation.put(prc.pcol, ColumnConstants.DEL_LOCK_PREFIX | prc.startTs,
+        DelLockValue.encodeRollback(true, true));
 
     ConditionalWriter cw = null;
 

--- a/modules/core/src/main/java/io/fluo/core/impl/TransactionImpl.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/TransactionImpl.java
@@ -661,7 +661,7 @@ public class TransactionImpl implements Transaction, Snapshot {
       m = new Flutation(env, row);
       for (Column col : updates.get(row).keySet()) {
         m.put(col, ColumnConstants.DEL_LOCK_PREFIX | startTs,
-            DelLockValue.encode(startTs, false, true));
+            DelLockValue.encodeRollback(false, true));
       }
       mutations.add(m);
     }
@@ -674,7 +674,7 @@ public class TransactionImpl implements Transaction, Snapshot {
     // TODO writing the primary column with a batch writer is iffy
 
     m.put(cd.pcol, ColumnConstants.DEL_LOCK_PREFIX | startTs,
-        DelLockValue.encode(startTs, false, true));
+        DelLockValue.encodeRollback(startTs, false, true));
     m.put(cd.pcol, ColumnConstants.TX_DONE_PREFIX | startTs, EMPTY);
 
     env.getSharedResources().getBatchWriter().writeMutation(m);

--- a/modules/core/src/main/java/io/fluo/core/impl/TxInfo.java
+++ b/modules/core/src/main/java/io/fluo/core/impl/TxInfo.java
@@ -63,17 +63,16 @@ public class TxInfo {
     } else if (colType == ColumnConstants.DEL_LOCK_PREFIX) {
       DelLockValue dlv = new DelLockValue(entry.getValue().get());
 
-      if (dlv.getTimestamp() != startTs) {
+      if (ts != startTs) {
         // expect this to always be false, must be a bug in the iterator
-        throw new IllegalStateException(prow + " " + pcol + " (" + dlv.getTimestamp() + " != "
-            + startTs + ") ");
+        throw new IllegalStateException(prow + " " + pcol + " (" + ts + " != " + startTs + ") ");
       }
 
       if (dlv.isRollback()) {
         txInfo.status = TxStatus.ROLLED_BACK;
       } else {
         txInfo.status = TxStatus.COMMITTED;
-        txInfo.commitTs = ts;
+        txInfo.commitTs = dlv.getCommitTimestamp();
       }
     } else if (colType == ColumnConstants.WRITE_PREFIX) {
       long timePtr = WriteValue.getTimestamp(entry.getValue().get());

--- a/modules/core/src/main/java/io/fluo/core/util/ColumnUtil.java
+++ b/modules/core/src/main/java/io/fluo/core/util/ColumnUtil.java
@@ -56,8 +56,8 @@ public class ColumnUtil {
       Flutation.put(env, m, col, ColumnConstants.WRITE_PREFIX | commitTs,
           WriteValue.encode(startTs, isPrimary, isDelete));
     } else {
-      Flutation.put(env, m, col, ColumnConstants.DEL_LOCK_PREFIX | commitTs,
-          DelLockValue.encode(startTs, isPrimary, false));
+      Flutation.put(env, m, col, ColumnConstants.DEL_LOCK_PREFIX | startTs,
+          DelLockValue.encodeCommit(commitTs, isPrimary));
     }
 
     if (isTrigger) {

--- a/modules/integration/src/test/java/io/fluo/integration/impl/CollisionIT.java
+++ b/modules/integration/src/test/java/io/fluo/integration/impl/CollisionIT.java
@@ -45,14 +45,14 @@ import org.junit.Test;
 
 /**
  * Run end to end test with lots of collisions and verify the following :
- * 
+ *
  * <p>
  * <ul>
  * <li/>LoaderExecutor works correctly w/ lots of collisions
  * <li/>Observers work correctly w/ lots of collisions
  * <li/>Fluo GC works correctly after lots of collisions
  * </ul>
- * 
+ *
  */
 public class CollisionIT extends ITBaseMini {
   static TypeLayer typeLayer = new TypeLayer(new StringEncoder());

--- a/modules/integration/src/test/resources/log4j.properties
+++ b/modules/integration/src/test/resources/log4j.properties
@@ -17,6 +17,7 @@ log4j.appender.CA=org.apache.log4j.ConsoleAppender
 log4j.appender.CA.layout=org.apache.log4j.PatternLayout
 log4j.appender.CA.layout.ConversionPattern=%d{ISO8601} [%c{2}] %-5p: %m%n
 
+log4j.logger.Audit=ERROR
 log4j.logger.org.apache.curator=ERROR
 log4j.logger.org.apache.accumulo.core.client.impl.ServerClient=ERROR
 log4j.logger.org.apache.accumulo.core.util.shell.Shell.audit=off


### PR DESCRIPTION
…zation to remove Accumulo delete iterator.

This change required modifying how delete lock markers sorted.  The change to
delete lock markers was made to enable safely seeking over delete markers after
seeing the 1st delete lock marker.  The way delete lock markers sorted before
this change did not lend itself to safe seeking.

Also the timestamps used for delete lock markers was made much more consistent.
Tried to use the exact timestamp of the lock being deleted.